### PR TITLE
Display the title properly when it is too long

### DIFF
--- a/src/app/components/card/card.component.html
+++ b/src/app/components/card/card.component.html
@@ -4,7 +4,7 @@
         <mat-icon mat-card-avatar matTooltip="{{'Private' | translate}}" *ngIf="this.status === 'private'" >lock</mat-icon>
         <mat-icon mat-card-avatar matTooltip="{{'Public' | translate}}" *ngIf="this.status === 'public'" >public</mat-icon>
         <mat-icon mat-card-avatar matTooltip="{{'Shared' | translate}}" *ngIf="this.status === 'shared'" >groups</mat-icon>
-        <mat-card-title (click)="clickOnAction(action.VIEW)" matTooltip="{{'View' | translate}}" [matTooltipPosition]="'above'">
+        <mat-card-title (click)="clickOnAction(action.VIEW)" matTooltip="{{'View' | translate}}&nbsp;{{card.title}}" [matTooltipPosition]="'above'">
             {{card.title}}
         </mat-card-title>
         <mat-card-subtitle class="subtitle">{{ 'Last update' | translate }} : {{card.last_update_date | date}}</mat-card-subtitle>

--- a/src/app/components/card/card.component.scss
+++ b/src/app/components/card/card.component.scss
@@ -21,15 +21,19 @@
 
         ::ng-deep .mat-card-header-text {
             margin: 0;
+            width: 175px;
         }
 
-        .mat-card-avatar{
+        .mat-card-avatar {
             font-size: 28px;
         }
 
         ::ng-deep .mat-card-title {
             font-weight: 400;
             cursor: pointer;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
         ::ng-deep .mat-card-title:hover {
@@ -47,7 +51,7 @@
         }
     }
 
-    .section_title{
+    .section_title {
         font-variant: small-caps;
     }
 
@@ -63,7 +67,7 @@
         .group {
             @include group();
 
-            &.mygroup{
+            &.mygroup {
                 background-color: #959595;
                 color: white;
             }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3,7 +3,7 @@
 	"Public": "Public",
 	"Shared": "Shared",
 	"View": "View",
-	"Last update": "",
+	"Last update": "Last update",
 	"Menu": "Menu",
 	"Readers": "Readers",
 	"Writers": "Writers",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -3,7 +3,7 @@
 	"Public": "Public",
 	"Shared": "Partagé",
 	"View": "Visualiser",
-	"Last update": "",
+	"Last update": "Modifié",
 	"Menu": "Menu",
 	"Readers": "Droit de lecture",
 	"Writers": "Droit d'écriture",


### PR DESCRIPTION
Fix #82

Also add a tooltip to see the full title :
![Capture d’écran 2021-03-30 à 17 25 55](https://user-images.githubusercontent.com/7236202/113015456-db3bc900-917d-11eb-8d65-5a8116d32bce.png)
