### PR TITLE
Serve arlas-wui-hub on port 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,6 @@ RUN rm -rf /usr/share/nginx/html/*
 COPY --from=hub /ng-app/dist/ /usr/share/nginx/html
 COPY --from=hub /ng-app/start.sh /usr/share/nginx/
 
-HEALTHCHECK CMD curl --fail http://localhost:80/ || exit 1
+HEALTHCHECK CMD curl --fail http://localhost:8080/ || exit 1
 
 CMD /usr/share/nginx/start.sh

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,6 +1,6 @@
 server {
 
-  listen 80;
+  listen 8080;
 
   sendfile on;
 


### PR DESCRIPTION
- the 80 port is a priviled prt that SonarQube recommends to avoid
- Fix #238 